### PR TITLE
Ventana ampliada

### DIFF
--- a/src/pages/datos-utiles/centros-salud/centros-salud-prestaciones.html
+++ b/src/pages/datos-utiles/centros-salud/centros-salud-prestaciones.html
@@ -5,60 +5,62 @@
 -->
 
 <ion-content *ngIf="centro">
-    <div *ngIf="!prestaciones" class="no-item">
-        <!-- <ion-spinner name="bubbles"></ion-spinner> -->
-        <ads-icon icon="ball-triangle"></ads-icon>
-    </div>
-    <h2 class="title">
-        {{centro.nombre}}
-    </h2>
-    <div class="subtitle">
-        <ul class="andes-list" compact>
-            <li (click)="navigateTo(centro.direccion.geoReferencia[0], centro.direccion.geoReferencia[1])">
+    <div class="contenedor-centro">
+        <div *ngIf="!prestaciones" class="no-item">
+            <!-- <ion-spinner name="bubbles"></ion-spinner> -->
+            <ads-icon icon="ball-triangle"></ads-icon>
+        </div>
+        <h2 class="title">
+            {{centro.nombre}}
+        </h2>
+        <div class="subtitle">
+            <ul class="andes-list" compact>
+                <li (click)="navigateTo(centro.direccion.geoReferencia[0], centro.direccion.geoReferencia[1])">
+                    <div class="andes-container">
+                        <ion-icon name="andes-marker-salud" class="left md"></ion-icon>
+                        <div class="andes-wraper">
+                            <h2 class="andes-list-title">
+                                <span class="remark"> {{centro.direccion.valor}} </span>
+                            </h2>
+                        </div>
+                    </div>
+                </li>
+            </ul>
+        </div>
+        <div class="subtitle" *ngIf="centro.contacto?.length">
+            <ul class="andes-list" compact>
+                <div *ngFor="let tel of centro.contacto">
+                    <li *ngIf="tel.tipo !== 'email'" (click)="call(tel.valor)">
+                        <div class="andes-container">
+                            <ion-icon name="andes-telefono" class="left md"></ion-icon>
+                            <div class="andes-wraper">
+                                <h2 class="andes-list-title">
+                                    <span class="remark"> {{ tel.valor }} </span>
+                                </h2>
+                            </div>
+                        </div>
+                    </li>
+                </div>
+            </ul>
+        </div>
+
+        <div class="subtitle">
+            <h5>PRESTACIONES</h5>
+        </div>
+        <ul class="andes-list" *ngIf="prestaciones?.length">
+            <li *ngFor="let p of prestaciones">
                 <div class="andes-container">
-                    <ion-icon name="andes-marker-salud" class="left md"></ion-icon>
                     <div class="andes-wraper">
-                        <h2 class="andes-list-title">
-                            <span class="remark"> {{centro.direccion.valor}} </span>
-                        </h2>
+                        <div class="andes-list-content">
+                            <div class="columna">
+                                <ion-icon name="checkmark"></ion-icon>
+                                <span class="andes-list-subtitle">{{p.nombre}} </span>
+                            </div>
+
+                        </div>
                     </div>
                 </div>
             </li>
         </ul>
     </div>
-    <div class="subtitle" *ngIf="centro.contacto?.length">
-        <ul class="andes-list" compact>
-            <div *ngFor="let tel of centro.contacto">
-                <li *ngIf="tel.tipo !== 'email'" (click)="call(tel.valor)">
-                    <div class="andes-container">
-                        <ion-icon name="andes-telefono" class="left md"></ion-icon>
-                        <div class="andes-wraper">
-                            <h2 class="andes-list-title">
-                                <span class="remark"> {{ tel.valor }} </span>
-                            </h2>
-                        </div>
-                    </div>
-                </li>
-            </div>
-        </ul>
-    </div>
-
-    <div class="subtitle">
-        <h5>PRESTACIONES</h5>
-    </div>
-    <ul class="andes-list" *ngIf="prestaciones?.length">
-        <li *ngFor="let p of prestaciones">
-            <div class="andes-container">
-                <div class="andes-wraper">
-                    <div class="andes-list-content">
-                        <div class="columna">
-                            <ion-icon name="checkmark"></ion-icon>
-                            <span class="andes-list-subtitle">{{p.nombre}} </span>
-                        </div>
-
-                    </div>
-                </div>
-            </div>
-        </li>
-    </ul>
 </ion-content>

--- a/src/pages/datos-utiles/centros-salud/centros-salud-prestaciones.html
+++ b/src/pages/datos-utiles/centros-salud/centros-salud-prestaciones.html
@@ -26,10 +26,10 @@
             </li>
         </ul>
     </div>
-    <div class="subtitle" *ngIf="centro.telecom.length">
+    <div class="subtitle" *ngIf="centro.contacto?.length">
         <ul class="andes-list" compact>
-            <div *ngFor="let tel of centro.telecom">
-                <li (click)="call(tel.valor)">
+            <div *ngFor="let tel of centro.contacto">
+                <li *ngIf="tel.tipo !== 'email'" (click)="call(tel.valor)">
                     <div class="andes-container">
                         <ion-icon name="andes-telefono" class="left md"></ion-icon>
                         <div class="andes-wraper">

--- a/src/pages/datos-utiles/centros-salud/centros-salud-prestaciones.scss
+++ b/src/pages/datos-utiles/centros-salud/centros-salud-prestaciones.scss
@@ -3,14 +3,21 @@
     font-size: 2rem;
     margin-bottom: 8px;
 }
+
 .subtitle {
     font-weight: 400;
     font-size: 1.6rem;
     margin: 0;
 }
+
 .subtitle h5 {
     margin: 30px 0 0 0;
 }
+
 li .andes-container .andes-wraper span {
     margin-left: 1rem;
+}
+
+.contenedor-centro {
+    margin: 0px 8px 0px 8px;
 }


### PR DESCRIPTION
Se mejoró la ventana ampliada de los efectores. Para acceder a ella se debe seleccionar Mapa de salud, un efector y poner botón "Ver más"
Lo que se realizó fue agregar un margen a la derecha e izquierda en toda la ventana para que se pueda leer mejor.
También se cambió los datos de donde se sacan los teléfonos. Ahora coincide con lo que se muestra en la app /tm/organizacion

Versión anterior
![ventana ampliada antes](https://user-images.githubusercontent.com/18200503/56738588-4cc59e00-6743-11e9-9d2d-65e2e40d5474.png)


Versión nueva
![ventana ampliada nueva](https://user-images.githubusercontent.com/18200503/56738591-4df6cb00-6743-11e9-91ec-b0aab6bf9915.png)
