### PR TITLE
Cierra infoWindow al seleccionar Ver más

### DIFF
--- a/src/pages/datos-utiles/centros-salud/map/map.html
+++ b/src/pages/datos-utiles/centros-salud/map/map.html
@@ -7,10 +7,8 @@
 
 <ion-content>
     <agm-map #gm [latitude]="center.latitude" [longitude]="center.longitude" [zoom]="zoom">
-        <agm-marker *ngIf="myPosition" [iconUrl]="'assets/icon/estoy_aca.png'" [latitude]="myPosition.latitude"
-            [longitude]="myPosition.longitude"></agm-marker>
-        <agm-marker *ngFor="let centro of centrosShow" (markerClick)="onClickCentro(centro); gm.lastOpen?.close(); gm.lastOpen = infoWindow"
-            [iconUrl]="'assets/icon/hospitallocation.png'" [latitude]="centro.direccion.geoReferencia[0]" [longitude]="centro.direccion.geoReferencia[1]">
+        <agm-marker *ngIf="myPosition" [iconUrl]="'assets/icon/estoy_aca.png'" [latitude]="myPosition.latitude" [longitude]="myPosition.longitude"></agm-marker>
+        <agm-marker *ngFor="let centro of centrosShow" (markerClick)="onClickCentro(centro); gm.lastOpen?.close(); gm.lastOpen = infoWindow" [iconUrl]="'assets/icon/hospitallocation.png'" [latitude]="centro.direccion.geoReferencia[0]" [longitude]="centro.direccion.geoReferencia[1]">
             <agm-info-window [disableAutoPan]="false" #infoWindow>
                 <div class="infowindow">
                     <div class="title">
@@ -28,7 +26,7 @@
                             <span>{{p.nombre}}</span>
                         </div>
                         <div>
-                            <p><button (click)="toPrestaciones(centro)">VER MÁS</button></p>
+                            <p><button (click)="gm.lastOpen?.close(); toPrestaciones(centro)">VER MÁS</button></p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Muy simple PR. 
En el mapa de salud, cuando se seleccionaba un efector y se iba a la ventana de "Ver más", 
![infowindow](https://user-images.githubusercontent.com/18200503/56813541-8bc32480-6813-11e9-8401-9092542e05df.png)

al volver al mapa se quedaba el infowindow roto, sin datos.
![Selection_002](https://user-images.githubusercontent.com/18200503/56813562-9a114080-6813-11e9-9b10-e7fe2b7b501a.png)

Entonces cerré el infowindow cuando se selecciona "Ver más" para que cuando se vuelva al mapa, se muestra el mapa en el mismo lugar que estaba centrado pero sin tener abierto el infowindow del efector recién seleccionado.

La idea es dejarlo abierto y con los datos cargados pero no logro hacerlo y no se ejecutan los métodos de ciclo de vida de ionic :man_shrugging: 
