### PR TITLE
Mapa de salud

### DIFF
--- a/src/pages/datos-utiles/centros-salud/map/map.html
+++ b/src/pages/datos-utiles/centros-salud/map/map.html
@@ -7,10 +7,8 @@
 
 <ion-content>
     <agm-map #gm [latitude]="center.latitude" [longitude]="center.longitude" [zoom]="zoom">
-        <agm-marker *ngIf="myPosition" [iconUrl]="'assets/icon/estoy_aca.png'" [latitude]="myPosition.latitude"
-            [longitude]="myPosition.longitude"></agm-marker>
-        <agm-marker *ngFor="let centro of centrosShow" (markerClick)="onClickCentro(centro); gm.lastOpen?.close(); gm.lastOpen = infoWindow"
-            [iconUrl]="'assets/icon/hospitallocation.png'" [latitude]="centro.direccion.geoReferencia[0]" [longitude]="centro.direccion.geoReferencia[1]">
+        <agm-marker *ngIf="myPosition" [iconUrl]="'assets/icon/estoy_aca.png'" [latitude]="myPosition.latitude" [longitude]="myPosition.longitude"></agm-marker>
+        <agm-marker *ngFor="let centro of centrosShow" (markerClick)="onClickCentro(centro); gm.lastOpen?.close(); gm.lastOpen = infoWindow" [iconUrl]="'assets/icon/hospitallocation.png'" [latitude]="centro.direccion.geoReferencia[0]" [longitude]="centro.direccion.geoReferencia[1]">
             <agm-info-window [disableAutoPan]="false" #infoWindow>
                 <div class="infowindow">
                     <div class="title">
@@ -28,7 +26,7 @@
                             <span>{{p.nombre}}</span>
                         </div>
                         <div>
-                            <p><button (click)="toPrestaciones(centro)">VER MÁS</button></p>
+                            <p><button (click)="gm.lastOpen?.close(); toPrestaciones(centro)">VER MÁS</button></p>
                         </div>
                     </div>
                 </div>

--- a/src/pages/datos-utiles/centros-salud/map/map.ts
+++ b/src/pages/datos-utiles/centros-salud/map/map.ts
@@ -30,7 +30,6 @@ export class MapPage implements OnDestroy {
 
     @ViewChild('infoWindow') infoWindow: ElementRef;
 
-    geoSubscribe;
     /* Es el CS seleccionado en la lista de CS mas cercanos*/
     public centroSaludSeleccionado: any;
     public prestaciones: any = [];
@@ -61,9 +60,6 @@ export class MapPage implements OnDestroy {
     ngOnDestroy() {
         if (this._locationsSubscriptions) {
             this._locationsSubscriptions.unsubscribe();
-        }
-        if (this.geoSubscribe) {
-            this.geoSubscribe.unsubscribe();
         }
     }
 
@@ -140,7 +136,7 @@ export class MapPage implements OnDestroy {
     }
 
     geoPosicionarme() {
-        this.geoSubscribe = this.maps.getGeolocation().then((position: any) => {
+        this.maps.getGeolocation().then((position: any) => {
             this.myPosition = position.coords;
             this.maps.setActual(this.myPosition);
             // Si me geolocaliza, centra el mapa donde estoy

--- a/src/pages/datos-utiles/centros-salud/map/map.ts
+++ b/src/pages/datos-utiles/centros-salud/map/map.ts
@@ -140,12 +140,13 @@ export class MapPage implements OnDestroy {
     }
 
     geoPosicionarme() {
-        this.geoSubscribe = this.maps.watchPosition().subscribe((position: any) => {
-            this.maps.setActual(this.myPosition);
+        this.geoSubscribe = this.maps.getGeolocation().then((position: any) => {
             this.myPosition = position.coords;
+            this.maps.setActual(this.myPosition);
             // Si me geolocaliza, centra el mapa donde estoy
             this.center.latitude = this.myPosition.latitude;
             this.center.longitude = this.myPosition.longitude
+            // }
         });
     }
 }


### PR DESCRIPTION
En el mapa de salud se estaba actualizando todo el tiempo la ubicación actual del usuario y centraba el mapa donde estaba parado. Además de resultar molesto, no permitía buscar efectores más lejos.
Ahora actualiza una sola vez la ubicación del usuario, mejorando la usabilidad y eficiencia de la app al no usar constantemente el GPS.

Además se modificó el infowindow de los efectores. Cuando se seleccionaba "Ver más",
infowindow
![56813541-8bc32480-6813-11e9-8401-9092542e05df](https://user-images.githubusercontent.com/18200503/56818285-b4501c00-681d-11e9-9a1c-71a8d5e076c1.png)

al volver al mapa se quedaba el infowindow roto, sin datos.
![image](https://user-images.githubusercontent.com/18200503/56818345-d3e74480-681d-11e9-825a-c0e18d0ef149.png)

Entonces cerré el infowindow cuando se selecciona "Ver más" para que cuando se vuelva al mapa, se muestra el mapa en el mismo lugar que estaba centrado pero sin tener abierto el infowindow del efector recién seleccionado.

La idea es dejarlo abierto y con los datos cargados pero no logro hacerlo y no se ejecutan los métodos de ciclo de vida de ionic :man_shrugging: