### PR TITLE
Lista efectores

### DIFF
--- a/src/pages/turnos/buscar/turnos-buscar.ts
+++ b/src/pages/turnos/buscar/turnos-buscar.ts
@@ -49,7 +49,6 @@ export class TurnosBuscarPage implements OnDestroy {
         public reporter: ErrorReporterProvider,
         public platform: Platform) {
 
-        this.efectores = this.navParams.get('organizaciones');
         this.prestacion = this.navParams.get('prestacion');
 
         this.onResumeSubscription = platform.resume.subscribe(() => {

--- a/src/pages/turnos/prestaciones/turnos-prestaciones.ts
+++ b/src/pages/turnos/prestaciones/turnos-prestaciones.ts
@@ -99,12 +99,7 @@ export class TurnosPrestacionesPage implements OnDestroy {
     }
 
     buscarTurnoPrestacion(prestacion) {
-        let organizaciones = this.organizacionAgendas.filter(unaOrg =>
-            unaOrg.agendas.filter(unaAgenda =>
-                unaAgenda.tipoPrestaciones.filter(unTipoPrestacion => unTipoPrestacion.conceptId === prestacion.conceptId)
-            )
-        );
-        this.navCtrl.push(TurnosBuscarPage, { organizaciones: organizaciones, prestacion: prestacion });
+        this.navCtrl.push(TurnosBuscarPage, { prestacion: prestacion });
     }
 
     onBugReport() {


### PR DESCRIPTION
Con este PR se corrige el bug de mostraba mal el listado de efectores al solicitar un turno. Lo que hacía es obtener del componente anterior el listado de efectores que poseen una agenda para mobile y lo mostraba. En otro momento obtenía los efectores con una agenda para esta prestación que te tenga turnos disponibles y ahí se modificaba el listado (disminuía la cantidad) mostrando los que corresponden.

Para replicar este error es necesario tener dos efectores con agenda para diferentes prestaciones con turnos mobile disponibles