### PR TITLE
Label rup

### DIFF
--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -101,7 +101,7 @@
                     <button class="item-icon outline circular" [disabled]="!isLogin()" (click)="rup()">
                         <ion-icon name="andes-vacuna"></ion-icon>
                     </button>
-                    <div class="fab-title" (click)="vacunas()"> RUP </div>
+                    <div class="fab-title" (click)="rup()"> RUP </div>
                 </div>
             </li>
         </ul>


### PR DESCRIPTION
En la pantalla de inicio del profesional, al saleccionar RUP en las letras y no el ícono, explotaba.
Ahora manda a RUP de la misma forma que si fuera en el ícono