### PR TITLE
fix(Campañas): chequea redirección al link de campañas de salud

### DIFF
--- a/src/pages/datos-utiles/campanias/detalle/campania-detalle.ts
+++ b/src/pages/datos-utiles/campanias/detalle/campania-detalle.ts
@@ -36,7 +36,14 @@ export class CampaniaDetallePage {
     }
 
     navigateTo(link) {
-        const browser = this.iab.create(link);
+        let https = 'https://';
+        let http = 'http://';
+        if (link.startsWith(https) || link.startsWith(http)) {
+            const browser = this.iab.create(link);
+        } else {
+
+            const browser = this.iab.create(`http://${link}`);
+        }
     }
 
 }

--- a/src/pages/gestion/acciones.ts
+++ b/src/pages/gestion/acciones.ts
@@ -274,6 +274,7 @@ export class AccionesComponent implements OnInit {
             totalMedicos = this.datos[0].consulta ? this.datos[0].consulta : 0;
             totalEnfermeros = this.datos[1].consulta ? this.datos[1].consulta : 0;
         }
+
         switch (this.datos[i].titulo) {
             case 'Otros':
                 for (let j = 0; j < i; j++) {


### PR DESCRIPTION
### Requerimiento
ISSUE #76 

### Funcionalidad desarrollada 
Se verifica que el link de la campaña de salud esté completo (comience con http:// o https://). En caso contrario, se lo agrega.

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
- [ ] Si
- [x] No

* se vuelve a hacer este PR porque el nombre de la rama tenía ñ, se cierra PR #77 
