### PR TITLE
TURNOS:Fix confirmar turno luego de que una agenda se pausa

### DIFF
--- a/src/pages/turnos/calendario/turnos-calendario.ts
+++ b/src/pages/turnos/calendario/turnos-calendario.ts
@@ -12,6 +12,7 @@ import { PacienteProvider } from '../../../providers/paciente';
 
 // page
 import { HomePage } from '../../home/home';
+import { TurnosPage } from '../turnos';
 import { FormArrayName } from '@angular/forms';
 import { group } from '@angular/core/src/animation/dsl';
 import { ErrorReporterProvider } from '../../../providers/errorReporter';
@@ -126,10 +127,16 @@ export class TurnosCalendarioPage {
                         this.navCtrl.popToRoot();
                     });
                 });
-            }).catch(() => {
-                this.toast.danger('El turno ya no está disponible, seleccione otro turno.', 800);
-                this.refreshAgendas();
-                this.confirmado = false;
+            }).catch((e) => {
+                if (e.message === 'La agenda ya no está disponible') {
+                    this.toast.danger(e.message, 800);
+                    this.confirmado = false;
+                    this.navCtrl.push(TurnosPage);
+                } else {
+                    this.toast.danger('El turno ya no está disponible, seleccione otro turno.', 800);
+                    this.refreshAgendas();
+                    this.confirmado = false;
+                }
             });
         }).catch((err) => {
             this.toast.danger('Error en la confirmación del turno, intente nuevamente');


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/AM-35

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se verifica si la api devolvió un error al verificar que la agenda no haya cambiado de estado, en el caso que haya ocurrido, muestra un _toast_ notificando al usuario que la agenda ya no esta disponible, y lo devuelve a _TurnosPage_ .



### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si https://github.com/andes/api/pull/939
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

