### PR TITLE
Historial de turnos: Se agrega efector

### DIFF
--- a/src/pages/turnos/historial/historial-turnos.html
+++ b/src/pages/turnos/historial/historial-turnos.html
@@ -21,6 +21,10 @@
                     <div class="badge light-gris" *ngIf="turno.asistencia==='sin datos'">sin datos de
                         asistencia</div>
                     <div class="andes-list-title"><strong>{{turno.tipoPrestacion.term}}</strong></div>
+                    <div>
+                        <ion-icon class="iconoProfesional" name="andes-hospital"></ion-icon>
+                        <small>{{turno.organizacion.nombre}}</small>
+                    </div>
                     <div class="profesional">
                         <ion-icon name="andes-profesional" class="iconoProfesional"></ion-icon>
                         <span class="light-gris" *ngIf="turno.profesionales.length">


### PR DESCRIPTION
### Requerimiento
Cuando se ingresa al historial de turnos de cada paciente, agregar el dato del efector correspondiente al turno

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega a la pantalla del historial de turnos, el efector correspondiente


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

