### PR TITLE
fix(RegistroMPI): Agrega controles y ignora sugeridos al escanear dni

### DIFF
--- a/src/app/pages/profesional/mpi/registro-paciente/registro-paciente.ts
+++ b/src/app/pages/profesional/mpi/registro-paciente/registro-paciente.ts
@@ -26,6 +26,7 @@ export class RegistroPacientePage {
 
     save() {
         this.saving = true;
+        this.paciente.ignoreSuggestions = true;
         if (this.paciente.entidadesValidadoras) {
             if (this.paciente.entidadesValidadoras.length <= 0) {
                 // Caso que el paciente existe y no tiene ninguna entidad validadora e ingresó como validado
@@ -62,22 +63,20 @@ export class RegistroPacientePage {
         const search = {
             documento: datos.documento.toString(),
             sexo: datos.sexo.toLowerCase(),
-            activo: true
+            activo: true,
+            estado: 'validado'
         };
 
         this.mpiService.get(search).then((resultado: any[]) => {
             if (resultado.length) {
                 this.paciente = resultado[0];
                 this.estado = this.paciente.estado;
-                if (this.paciente.estado === 'temporal') {
-                    this.paciente.estado = 'validado';
-                    this.paciente.scan = scan;
-                    this.paciente.nombre = datos.nombre.toUpperCase();
-                    this.paciente.apellido = datos.apellido.toUpperCase();
-                    this.paciente.fechaNacimiento = moment(datos.fechaNacimiento, 'DD/MM/YYYY');
-                    this.paciente.sexo = datos.sexo.toLowerCase();
-                    this.paciente.documento = datos.documento;
-                }
+                this.paciente.scan = scan;
+                this.paciente.nombre = datos.nombre.toUpperCase();
+                this.paciente.apellido = datos.apellido.toUpperCase();
+                this.paciente.fechaNacimiento = moment(datos.fechaNacimiento, 'DD/MM/YYYY');
+                this.paciente.sexo = datos.sexo.toLowerCase();
+                this.paciente.documento = datos.documento;
                 this.inProgress = false;
             } else {
                 // No existe el paciente


### PR DESCRIPTION
### Requerimiento

- Modificar scan de dni para que al guardar el paciente escaneado no verifique las sugerencias, sino decía que lo guardaba y no lo hacía. 

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega estado validado al hacer el get
2. Se envia variable ignoreSuggestions en true para que no traiga las sugerencias

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


